### PR TITLE
Add android orientation and screenSize config changes

### DIFF
--- a/java/app/src/main/AndroidManifest.xml
+++ b/java/app/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         tools:targetApi="31">
         <activity
             android:name=".MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:configChanges="orientation|screenSize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/kotlin/app/src/main/AndroidManifest.xml
+++ b/kotlin/app/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         tools:targetApi="31">
         <activity
             android:name=".MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:configChanges="orientation|screenSize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
Until now, when the screen was rotated, the MainActivity (and its fragments) were destroyed and recreated, which would end up in reloading the webview and losing some data like the event listener and the current participant leaving and rejoining the meeting. 

This fixes the issue by avoiding recreating the Activity on screen rotation. 

I'm interested in investigating if there is a better way to do so, like using viewModel. I'll post my finding in a Linear ticket. 

**Test plan**
1. In the MainActivity, set the `mRoomUrlString` property and run the app
2. From the settings (swipe down from the top), check the `auto-rotate` is on.
3. Join the room using either embedded or fullscreen presentation
4. Rotate the device. Confirm the webview is **not** reloaded anymore. 

**Test plan**
If approved, I'll update our documentation. 